### PR TITLE
Update README to reflect correct image path for MediSearch interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A modern web application that provides intelligent medical information assistance through a conversational interface. The application is built with security, reliability, and user experience in mind.
 
-![MediSearch Interface](./client/public/MediSearch.png)
+![MediSearch Interface](./frontend/public/MediSearch.png)
 
 ## TEAM MEMBERS
 - Luswata Andrew


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. The change updates the path to the MediSearch interface image to reflect the new directory structure.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5-R5): Updated the path to the MediSearch interface image from `./client/public/MediSearch.png` to `./frontend/public/MediSearch.png`.